### PR TITLE
Add tests and change configuration from add to long/short

### DIFF
--- a/src/EuropeanOption.h
+++ b/src/EuropeanOption.h
@@ -73,8 +73,11 @@ namespace ValLry{
             // template definition for the main pricing function
             template<typename out_type, typename t_type, typename S_type>
             out_type internal_price(t_type t, S_type S){
+
+                if(!_isPositionDefined){throw(std::runtime_error("Position in portfolio has not been set up!\n"));}
+                if(!_default_model_especified){throw(std::runtime_error("Default model has not been specified!"));}
+
                 out_type price;
-                if(_default_model_especified){
                 switch (_model)
                 {
                 case PricingModel::BLACK_SCHOLES:
@@ -87,9 +90,12 @@ namespace ValLry{
                     throw(std::runtime_error("Model is not valid"));
                     break;
                 }
-                }else{
-                    throw(std::runtime_error("Default model has not been specified!"));
+
+                //If we are shorting the instrument, its value is multiplied by -1
+                if(_BookPosition == Position::SHORT){
+                    price = -price;
                 }
+                    
                 return price;
             }
            

--- a/src/FinancialInstrument.cpp
+++ b/src/FinancialInstrument.cpp
@@ -24,5 +24,6 @@ namespace ValLry{
 
     void FinancialInstrument::setBookPosition(const Position &BookPosition){
         _BookPosition = BookPosition;
+        _isPositionDefined = true;
     }
 }

--- a/src/FinancialInstrument.h
+++ b/src/FinancialInstrument.h
@@ -15,7 +15,10 @@ namespace ValLry{
 
             double _MTM; //Market Price
             double _NPV; //Computed price
+
+        protected:
             Position _BookPosition;  //Short or Long
+            bool _isPositionDefined = false;
 
         public:
             //Price the instrument according to its configuration. It needs to be defined in each inherited class.

--- a/src/Portfolio.cpp
+++ b/src/Portfolio.cpp
@@ -7,6 +7,13 @@ namespace ValLry{
         for(auto &instrument : _composition){
             price +=instrument.second->price(t,S);
         }
+        
+        if(_isPositionDefined){ //We do not always need the our portfolio has a position, only when is a portfolio in other portfolio
+            //If we are shorting the portfolio, its value is multiplied by -1
+            if(_BookPosition == Position::SHORT){
+                price = -price;
+            }
+        }
         return price;
     }
 
@@ -19,13 +26,22 @@ namespace ValLry{
             for (size_t i = 0; i < t_vector->size(); ++i) {
                 (*price)[i] += price_ins_vector->at(i);
             }
+
+            if(_isPositionDefined){ //We do not always need the our portfolio has a position, only when is a portfolio in other portfolio
+                for (size_t i = 0; i < t_vector->size(); ++i) {
+                    //If we are shorting the portfolio, its value is multiplied by -1
+                    if(_BookPosition == Position::SHORT){
+                        (*price)[i]*=(-1);
+                    }
+                }
+            }
         }
+        
         auto price_np = vector2numpy(price);
         return price_np;
     }
     
     py::array_t<double> portfolio::price(const double t, const py::array_t<double> S){
-        try{
         std::vector<double> price;
         std::shared_ptr<std::vector<double>> S_vector = numpy2vector(S);
         for (size_t i = 0; i < S_vector->size(); ++i) {price.push_back(0.0);}
@@ -36,13 +52,17 @@ namespace ValLry{
                 price[i] += price_ins_vector->at(i);
             }
         }
+        if(_isPositionDefined){ //We do not always need the our portfolio has a position, only when is a portfolio in other portfolio
+            for (size_t i = 0; i < S_vector->size(); ++i) {
+                //If we are shorting the portfolio, its value is multiplied by -1
+                if(_BookPosition == Position::SHORT){
+                    price[i]*=(-1);
+                }
+            }
+        }
         std::shared_ptr<std::vector<double>> price_ptr = std::make_shared<std::vector<double>>(price);
         py::array_t<double> price_np = vector2numpy(price_ptr);
         return price_np;
-        }
-        catch(...){
-            throw std::runtime_error("SOmething went wrong");
-        }
     }
 
     void portfolio::addInstrument(std::string label, const std::shared_ptr<FinancialInstrument> &instrument){
@@ -53,6 +73,17 @@ namespace ValLry{
             throw(std::runtime_error("portfolio::addInstrument : label is already in the porfolio"));
         }
     }
+
+    void portfolio::longInstrument(std::string label, std::shared_ptr<FinancialInstrument> &instrument){
+        instrument->setBookPosition(Position::LONG);
+        addInstrument(label, instrument);
+    }
+
+    void portfolio::shortInstrument(std::string label, std::shared_ptr<FinancialInstrument> &instrument){
+        instrument->setBookPosition(Position::SHORT);
+        addInstrument(label, instrument);
+    }
+
     void portfolio::eraseInstrument(const std::string label){
         if(_composition.find(label)!=_composition.end()){
             _label_list.erase(label);

--- a/src/Portfolio.h
+++ b/src/Portfolio.h
@@ -24,6 +24,8 @@ namespace ValLry {
             py::array_t<double> price(const double t, const py::array_t<double> S);
 
             void addInstrument(std::string label, const std::shared_ptr<FinancialInstrument> &instrument);
+            void longInstrument(std::string label, std::shared_ptr<FinancialInstrument> &instrument);
+            void shortInstrument(std::string label, std::shared_ptr<FinancialInstrument> &instrument);
             void eraseInstrument(const std::string label);
             std::set<std::string> getLabelList();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,12 +45,14 @@ PYBIND11_MODULE(ValuationLibrary, m) {
         .def_readonly("BSM", &ValLry::EuropeanOption::BSM); 
 
     //Portfolio
-     py::class_<ValLry::portfolio>(m, "portfolio")
+     py::class_<ValLry::portfolio, ValLry::FinancialInstrument, std::shared_ptr<ValLry::portfolio>>(m, "portfolio")
         .def(py::init<>())
         .def("price", py::overload_cast<const double, const double>(&ValLry::portfolio::price), "price function that takes double as t and S")
         .def("price", py::overload_cast<const py::array_t<double>, const double>(&ValLry::portfolio::price),"price fuction that takes numpy array as t")
         .def("price", py::overload_cast<const double, const py::array_t<double>>(&ValLry::portfolio::price),"price fuction that takes numpy array as S")
         .def("addInstrument", &ValLry::portfolio::addInstrument)
+        .def("longInstrument", &ValLry::portfolio::longInstrument)
+        .def("shortInstrument", &ValLry::portfolio::shortInstrument)
         .def("eraseInstrument", &ValLry::portfolio::eraseInstrument)
         .def("getLabelList", &ValLry::portfolio::getLabelList);
 }

--- a/tests/buttelfly_spread.py
+++ b/tests/buttelfly_spread.py
@@ -1,0 +1,51 @@
+import ValuationLibrary as ValLry
+import numpy as np
+import matplotlib.pyplot as plt
+
+#BSM parameters
+vol = 0.2
+r = 0.02
+
+#Define a strategy portfolio
+Straddle = ValLry.portfolio()
+
+
+################## CREATE STRADDLE ####################################
+dK = 10.
+K0 = 100.
+
+strikes = [K0 - dK, K0, K0, K0 + dK]
+positions = ['L', 'S', 'S', 'L']
+
+i = 0
+for K in strikes:
+
+    #Define a European Option
+    OpcionCall = ValLry.EuropeanOption(ValLry.OptionType.PUT,K, 1.)
+
+    #set the default model
+    OpcionCall.BSM.setup(vol, r)
+    OpcionCall.setPricingModel(ValLry.PricingModel.BLACK_SCHOLES)
+
+    #Add option to portfolio
+    if(positions[i] == 'L'):
+        Straddle.longInstrument("Option_{}".format(i), OpcionCall)
+    else:
+        Straddle.shortInstrument("Option_{}".format(i), OpcionCall)
+
+    i += 1
+
+#####################################################################
+
+# Payoff butterfly spread
+S = np.linspace(K0 - 2 * dK, K0 + 2 * dK, 100)
+Value_straddle = Straddle.price(1.,S)
+plt.plot(S,Value_straddle)
+plt.show()
+
+# Price butterfly spread
+Value_straddle = Straddle.price(0.,S)
+plt.plot(S,Value_straddle)
+plt.show()
+
+print("d2C/dK2 =(aprox)= {}".format(Straddle.price(0.,K0)/(dK)**2))

--- a/tests/portfolio_straddle.py
+++ b/tests/portfolio_straddle.py
@@ -1,0 +1,52 @@
+import ValuationLibrary as ValLry
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+#Define a strategy portfolio
+Straddle = ValLry.portfolio()
+
+
+################## CREATE STRADDLE ####################################
+
+#Define a European Option
+OpcionCall = ValLry.EuropeanOption(ValLry.OptionType.PUT,100., 1.)
+
+#set the default model
+OpcionCall.BSM.setup(0.2, 0.02)
+OpcionCall.setPricingModel(ValLry.PricingModel.BLACK_SCHOLES)
+
+#Add option to portfolio
+Straddle.longInstrument("Option_PUT", OpcionCall)
+
+#Define a European Option
+OpcionCall = ValLry.EuropeanOption(ValLry.OptionType.CALL,100., 1.)
+
+#set the default model
+OpcionCall.BSM.setup(0.2, 0.02)
+OpcionCall.setPricingModel(ValLry.PricingModel.BLACK_SCHOLES)
+
+#Add option to portfolio
+Straddle.longInstrument("Option_CALL", OpcionCall)
+
+#get the list of instruments in the porfolio
+portfolioList = Straddle.getLabelList()
+print(portfolioList)
+
+#####################################################################
+
+# Price the straddle
+S = np.linspace(0., 200., 100)
+Value_straddle = Straddle.price(0.99,S)
+plt.plot(S,Value_straddle)
+plt.show()
+
+# Create new big portfolio
+book = ValLry.portfolio()
+
+book.shortInstrument("Stradle", Straddle)
+
+S = np.linspace(0., 200., 100)
+Value_book = book.price(0.99,S)
+plt.plot(S,Value_book)
+plt.show()


### PR DESCRIPTION
The portfolio has now the options to short or buy long some instruments (including other portfolios). With this, short portfolios will change its sign when shorting.

Two test cases has been added: a portfolio with a straddle strategy and other with a butterfly spread.